### PR TITLE
fix: correct wc-print-contexts.yml workflow filename

### DIFF
--- a/.github/workflows/branch_protection_rule_created.yml
+++ b/.github/workflows/branch_protection_rule_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: branch_protection_rule_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/branch_protection_rule_deleted.yml
+++ b/.github/workflows/branch_protection_rule_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: branch_protection_rule_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/branch_protection_rule_edited.yml
+++ b/.github/workflows/branch_protection_rule_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: branch_protection_rule_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/check_run_completed.yml
+++ b/.github/workflows/check_run_completed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: check_run_completed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/check_run_created.yml
+++ b/.github/workflows/check_run_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: check_run_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/check_run_requested_action.yml
+++ b/.github/workflows/check_run_requested_action.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: check_run_requested_action-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/check_run_rerequested.yml
+++ b/.github/workflows/check_run_rerequested.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: check_run_rerequested-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/check_suite_completed.yml
+++ b/.github/workflows/check_suite_completed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: check_suite_completed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: create-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: delete-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: deployment-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/deployment_status.yml
+++ b/.github/workflows/deployment_status.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: deployment_status-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_answered.yml
+++ b/.github/workflows/discussion_answered.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_answered-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_category_changed.yml
+++ b/.github/workflows/discussion_category_changed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_category_changed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_comment_created.yml
+++ b/.github/workflows/discussion_comment_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_comment_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_comment_deleted.yml
+++ b/.github/workflows/discussion_comment_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_comment_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_comment_edited.yml
+++ b/.github/workflows/discussion_comment_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_comment_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_created.yml
+++ b/.github/workflows/discussion_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_deleted.yml
+++ b/.github/workflows/discussion_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_edited.yml
+++ b/.github/workflows/discussion_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_labeled.yml
+++ b/.github/workflows/discussion_labeled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_labeled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_locked.yml
+++ b/.github/workflows/discussion_locked.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_locked-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_pinned.yml
+++ b/.github/workflows/discussion_pinned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_pinned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_transferred.yml
+++ b/.github/workflows/discussion_transferred.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_transferred-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_unanswered.yml
+++ b/.github/workflows/discussion_unanswered.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_unanswered-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_unlabeled.yml
+++ b/.github/workflows/discussion_unlabeled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_unlabeled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_unlocked.yml
+++ b/.github/workflows/discussion_unlocked.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_unlocked-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/discussion_unpinned.yml
+++ b/.github/workflows/discussion_unpinned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: discussion_unpinned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/fork.yml
+++ b/.github/workflows/fork.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: fork-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/gollum.yml
+++ b/.github/workflows/gollum.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: gollum-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issue_comment_created.yml
+++ b/.github/workflows/issue_comment_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issue_comment_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issue_comment_deleted.yml
+++ b/.github/workflows/issue_comment_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issue_comment_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issue_comment_edited.yml
+++ b/.github/workflows/issue_comment_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issue_comment_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_assigned.yml
+++ b/.github/workflows/issues_assigned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_assigned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_closed.yml
+++ b/.github/workflows/issues_closed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_closed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_deleted.yml
+++ b/.github/workflows/issues_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_demilestoned.yml
+++ b/.github/workflows/issues_demilestoned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_demilestoned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_edited.yml
+++ b/.github/workflows/issues_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_labeled.yml
+++ b/.github/workflows/issues_labeled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_labeled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_locked.yml
+++ b/.github/workflows/issues_locked.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_locked-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_milestoned.yml
+++ b/.github/workflows/issues_milestoned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_milestoned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_opened.yml
+++ b/.github/workflows/issues_opened.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_opened-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_pinned.yml
+++ b/.github/workflows/issues_pinned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_pinned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_reopened.yml
+++ b/.github/workflows/issues_reopened.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_reopened-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_transferred.yml
+++ b/.github/workflows/issues_transferred.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_transferred-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_unassigned.yml
+++ b/.github/workflows/issues_unassigned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_unassigned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_unlabeled.yml
+++ b/.github/workflows/issues_unlabeled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_unlabeled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_unlocked.yml
+++ b/.github/workflows/issues_unlocked.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_unlocked-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/issues_unpinned.yml
+++ b/.github/workflows/issues_unpinned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: issues_unpinned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/label_created.yml
+++ b/.github/workflows/label_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: label_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/label_deleted.yml
+++ b/.github/workflows/label_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: label_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/label_edited.yml
+++ b/.github/workflows/label_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: label_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/merge_group_checks_requested.yml
+++ b/.github/workflows/merge_group_checks_requested.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: merge_group_checks_requested-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/milestone_closed.yml
+++ b/.github/workflows/milestone_closed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: milestone_closed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/milestone_created.yml
+++ b/.github/workflows/milestone_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: milestone_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/milestone_deleted.yml
+++ b/.github/workflows/milestone_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: milestone_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/milestone_edited.yml
+++ b/.github/workflows/milestone_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: milestone_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/milestone_opened.yml
+++ b/.github/workflows/milestone_opened.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: milestone_opened-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/page_build.yml
+++ b/.github/workflows/page_build.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: page_build-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_card_converted.yml
+++ b/.github/workflows/project_card_converted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_card_converted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_card_created.yml
+++ b/.github/workflows/project_card_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_card_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_card_deleted.yml
+++ b/.github/workflows/project_card_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_card_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_card_edited.yml
+++ b/.github/workflows/project_card_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_card_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_card_moved.yml
+++ b/.github/workflows/project_card_moved.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_card_moved-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_closed.yml
+++ b/.github/workflows/project_closed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_closed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_column_created.yml
+++ b/.github/workflows/project_column_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_column_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_column_deleted.yml
+++ b/.github/workflows/project_column_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_column_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_column_moved.yml
+++ b/.github/workflows/project_column_moved.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_column_moved-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_column_updated.yml
+++ b/.github/workflows/project_column_updated.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_column_updated-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_created.yml
+++ b/.github/workflows/project_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_deleted.yml
+++ b/.github/workflows/project_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_edited.yml
+++ b/.github/workflows/project_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/project_reopened.yml
+++ b/.github/workflows/project_reopened.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: project_reopened-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/public.yml
+++ b/.github/workflows/public.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: public-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_assigned.yml
+++ b/.github/workflows/pull_request_assigned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_assigned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_auto_merge_disabled.yml
+++ b/.github/workflows/pull_request_auto_merge_disabled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_auto_merge_disabled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_auto_merge_enabled.yml
+++ b/.github/workflows/pull_request_auto_merge_enabled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_auto_merge_enabled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_closed.yml
+++ b/.github/workflows/pull_request_closed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_closed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_converted_to_draft.yml
+++ b/.github/workflows/pull_request_converted_to_draft.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_converted_to_draft-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_edited.yml
+++ b/.github/workflows/pull_request_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_labeled.yml
+++ b/.github/workflows/pull_request_labeled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_labeled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_locked.yml
+++ b/.github/workflows/pull_request_locked.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_locked-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_opened.yml
+++ b/.github/workflows/pull_request_opened.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_opened-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_ready_for_review.yml
+++ b/.github/workflows/pull_request_ready_for_review.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_ready_for_review-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_reopened.yml
+++ b/.github/workflows/pull_request_reopened.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_reopened-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_review_comment_created.yml
+++ b/.github/workflows/pull_request_review_comment_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_review_comment_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_review_comment_deleted.yml
+++ b/.github/workflows/pull_request_review_comment_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_review_comment_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_review_comment_edited.yml
+++ b/.github/workflows/pull_request_review_comment_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_review_comment_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_review_dismissed.yml
+++ b/.github/workflows/pull_request_review_dismissed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_review_dismissed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_review_edited.yml
+++ b/.github/workflows/pull_request_review_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_review_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_review_request_removed.yml
+++ b/.github/workflows/pull_request_review_request_removed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_review_request_removed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_review_requested.yml
+++ b/.github/workflows/pull_request_review_requested.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_review_requested-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_review_submitted.yml
+++ b/.github/workflows/pull_request_review_submitted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_review_submitted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_synchronize.yml
+++ b/.github/workflows/pull_request_synchronize.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_synchronize-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_assigned.yml
+++ b/.github/workflows/pull_request_target_assigned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_assigned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_auto_merge_disabled.yml
+++ b/.github/workflows/pull_request_target_auto_merge_disabled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_auto_merge_disabled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_auto_merge_enabled.yml
+++ b/.github/workflows/pull_request_target_auto_merge_enabled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_auto_merge_enabled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_closed.yml
+++ b/.github/workflows/pull_request_target_closed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_closed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_converted_to_draft.yml
+++ b/.github/workflows/pull_request_target_converted_to_draft.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_converted_to_draft-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_edited.yml
+++ b/.github/workflows/pull_request_target_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_labeled.yml
+++ b/.github/workflows/pull_request_target_labeled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_labeled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_locked.yml
+++ b/.github/workflows/pull_request_target_locked.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_locked-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_opened.yml
+++ b/.github/workflows/pull_request_target_opened.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_opened-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_ready_for_review.yml
+++ b/.github/workflows/pull_request_target_ready_for_review.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_ready_for_review-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_reopened.yml
+++ b/.github/workflows/pull_request_target_reopened.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_reopened-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_review_request_removed.yml
+++ b/.github/workflows/pull_request_target_review_request_removed.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_review_request_removed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_review_requested.yml
+++ b/.github/workflows/pull_request_target_review_requested.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_review_requested-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_synchronize.yml
+++ b/.github/workflows/pull_request_target_synchronize.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_synchronize-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_unassigned.yml
+++ b/.github/workflows/pull_request_target_unassigned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_unassigned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_unlabeled.yml
+++ b/.github/workflows/pull_request_target_unlabeled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_unlabeled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_target_unlocked.yml
+++ b/.github/workflows/pull_request_target_unlocked.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_target_unlocked-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_unassigned.yml
+++ b/.github/workflows/pull_request_unassigned.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_unassigned-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_unlabeled.yml
+++ b/.github/workflows/pull_request_unlabeled.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_unlabeled-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/pull_request_unlocked.yml
+++ b/.github/workflows/pull_request_unlocked.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: pull_request_unlocked-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: push-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/registry_package_published.yml
+++ b/.github/workflows/registry_package_published.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: registry_package_published-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/registry_package_updated.yml
+++ b/.github/workflows/registry_package_updated.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: registry_package_updated-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/release_created.yml
+++ b/.github/workflows/release_created.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: release_created-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/release_deleted.yml
+++ b/.github/workflows/release_deleted.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: release_deleted-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/release_edited.yml
+++ b/.github/workflows/release_edited.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: release_edited-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/release_prereleased.yml
+++ b/.github/workflows/release_prereleased.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: release_prereleased-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/release_published.yml
+++ b/.github/workflows/release_published.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: release_published-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/release_released.yml
+++ b/.github/workflows/release_released.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: release_released-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/release_unpublished.yml
+++ b/.github/workflows/release_unpublished.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: release_unpublished-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: repository_dispatch-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -5,4 +5,4 @@ on:
 jobs:
   print-context:
     concurrency: schedule-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -4,4 +4,4 @@ on:
 jobs:
   print-context:
     concurrency: status-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/watch_started.yml
+++ b/.github/workflows/watch_started.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   print-context:
     concurrency: watch_started-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/workflow_run_completed.yml
+++ b/.github/workflows/workflow_run_completed.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   print-context:
     concurrency: workflow_run_completed-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml

--- a/.github/workflows/workflow_run_requested.yml
+++ b/.github/workflows/workflow_run_requested.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   print-context:
     concurrency: workflow_run_requested-${{ github.ref }}
-    uses: ./.github/workflows/wc-print-context.yml
+    uses: ./.github/workflows/wc-print-contexts.yml


### PR DESCRIPTION
The Workflow Call workflow filename used by all of the other workflows was incorrectly specified as `./.github/workflows/wc-print-context.yml` when it should have been `./.github/workflows/wc-print-contexts.yml`.